### PR TITLE
Add support to generically handle ActiveRecord::NotNullViolation exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,12 @@ class ApplicationController < ActionController::API
     render :json => exception.error_document.to_h, :status => exception.error_document.status
   end
 
+  rescue_from ActiveRecord::NotNullViolation do |exception|
+    exception_msg = exception.message.split("\n").first.gsub("PG::NotNullViolation: ERROR:  ", "")
+    error_document = ManageIQ::API::Common::ErrorDocument.new.add(400, "Missing parameter - #{exception_msg}")
+    render :json => error_document.to_h, :status => :bad_request
+  end
+
   rescue_from Sources::Api::BodyParseError do |exception|
     error_document = ManageIQ::API::Common::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
     render :json => error_document.to_h, :status => error_document.status

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe("v1.0 - Sources") do
         )
       end
 
+      it "failure: with a missing name attribute" do
+        post(collection_path, :params => attributes.except("name").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, a_string_starting_with("Missing parameter - null value in column \"name\"")).to_h
+        )
+      end
+
       it "failure: with extra attributes" do
         post(collection_path, :params => attributes.merge("aaa" => "bbb").to_json, :headers => headers)
 


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/TPINVTRY-222


Add support to generically handle ActiveRecord::NotNullViolation exceptions and return a proper error message instead of the 500 internal error.

Massage the exception message to get the following example:

{
  "errors": [
    {
      "status": 400,
      "detail": "Missing parameter - null value in column \"name\" violates not-null constraint"
    }
  ]
}