### PR TITLE
Assures that name specified is specified and not blank

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,12 @@ class ApplicationController < ActionController::API
     render :json => error_document.to_h, :status => :not_found
   end
 
+  rescue_from ActiveRecord::RecordInvalid do |exception|
+    exception_msg = exception.message.split("\n").first.gsub("ActiveRecord::RecordInvalid: ", "")
+    error_document = ManageIQ::API::Common::ErrorDocument.new.add(400, "Invalid parameter - #{exception_msg}")
+    render :json => error_document.to_h, :status => :bad_request
+  end
+
   rescue_from ManageIQ::API::Common::Filter::Error do |exception|
     render :json => exception.error_document.to_h, :status => exception.error_document.status
   end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -10,6 +10,7 @@ class Source < ApplicationRecord
 
   delegate :scheme, :scheme=, :host, :host=, :port, :port=, :path, :path=,
            :to => :default_endpoint, :allow_nil => true
+  validates :name, :presence => true, :allow_blank => false
 
   def default_endpoint
     default = endpoints.detect(&:default)

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe("v1.0 - Sources") do
           :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
+
+      it "failure: with a blank name attribute" do
+        post(collection_path, :params => attributes.merge("name" => "").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
+        )
+      end
     end
   end
 


### PR DESCRIPTION

This fixes: https://projects.engineering.redhat.com/browse/TPINVTRY-223

Added model validator to assure that name is specified and is non-blank,
added rescue for ActiveRecord::RecordInvalid and appropriate spec for the empty name scenario.
