### PR TITLE
Fix for POST create openapi JSON signatures

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -273,10 +273,7 @@ class OpenapiGenerator
           "description" => "#{klass_name} creation successful",
           "content"     => {
             "application/json" => {
-              "schema" => {
-                "type"  => "object",
-                "items" => { "$ref" => build_schema(klass_name) }
-              }
+              "schema" => { "$ref" => build_schema(klass_name) }
             }
           }
         }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -127,10 +127,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "items": {
-                    "$ref": "#/components/schemas/Application"
-                  }
+                  "$ref": "#/components/schemas/Application"
                 }
               }
             }
@@ -233,10 +230,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "items": {
-                    "$ref": "#/components/schemas/Authentication"
-                  }
+                  "$ref": "#/components/schemas/Authentication"
                 }
               }
             }
@@ -371,10 +365,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "items": {
-                    "$ref": "#/components/schemas/Endpoint"
-                  }
+                  "$ref": "#/components/schemas/Endpoint"
                 }
               }
             }
@@ -553,10 +544,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "items": {
-                    "$ref": "#/components/schemas/SourceType"
-                  }
+                  "$ref": "#/components/schemas/SourceType"
                 }
               }
             }
@@ -674,10 +662,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "items": {
-                    "$ref": "#/components/schemas/Source"
-                  }
+                  "$ref": "#/components/schemas/Source"
                 }
               }
             }


### PR DESCRIPTION
  Response signatures like:

             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "items": {
                     "$ref": "#/components/schemas/Source"
                   }
                 }
               }
             }

  Should just be for simple json objects and not arrays:

             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Source"
                 }
               }
             }