### PR TITLE
Disable Kafka using an environment variable.

### DIFF
--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -2,6 +2,7 @@ module Sources
   module Api
     module Events
       def self.raise_event(event, payload)
+        return if ENV['NO_KAFKA']
         messaging_client.publish_topic(
           :service => "platform.sources.event-stream",
           :event   => event,


### PR DESCRIPTION
I'd like to have a way to disable kafka communication to simplify local setup.

What is the best way to do it? Something under `config/environment*`? Or an environment variable like in this PR? Or combination?