### PR TITLE
Fix Net undefined exception when generating client

### DIFF
--- a/lib/tasks/client_generate.rake
+++ b/lib/tasks/client_generate.rake
@@ -26,6 +26,8 @@ class ClientGenerator
     @generator_cli_jar ||= begin
       jar_path = Pathname.new(Rails.root.join("public/doc/openapi-generator-cli-#{VERSION}.jar"))
       unless File.exist?(jar_path) && File.size(jar_path).positive?
+        require "net/http"
+
         source_url = "#{SOURCE_URL}/#{VERSION}/openapi-generator-cli-#{VERSION}.jar"
         cli_res = Net::HTTP.get_response(URI(source_url))
         raise "Failed to get the #{source_url} - #{cli_res.message}" unless cli_res.kind_of?(Net::HTTPSuccess)


### PR DESCRIPTION
```
Sources API Version: 1.0
rake aborted!
NameError: uninitialized constant Net
/home/agrare/src/topological_inventory/sources-api/lib/tasks/client_generate.rake:30:in `generator_cli_jar'
/home/agrare/src/topological_inventory/sources-api/lib/tasks/client_generate.rake:57:in `generate_client'
/home/agrare/src/topological_inventory/sources-api/lib/tasks/client_generate.rake:74:in `block (2 levels) in <top (required)>'
/home/agrare/.gem/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
Tasks: TOP => client:generate
(See full trace by running task with --trace)
```