### PR TITLE
Add in the x-rh-identity headers to the event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.1'
-gem 'manageiq-messaging',   '~> 0.1.2', :require => false
+gem 'manageiq-messaging',   '~> 0.1.5', :require => false
 gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"
 gem 'more_core_extensions', '~> 3.5'
 gem 'pg',                   '~> 1.0', :require => false

--- a/app/controllers/api/v1/authentications_controller.rb
+++ b/app/controllers/api/v1/authentications_controller.rb
@@ -8,9 +8,7 @@ module Api
 
       def create
         authentication = model.create!(params_for_create)
-
-        Sources::Api::Events.raise_event("#{model}.create", authentication.as_json)
-
+        raise_event("#{model}.create", authentication.as_json)
         render :json => authentication, :status => :created, :location => instance_link(authentication)
       end
     end

--- a/app/controllers/api/v1/endpoints_controller.rb
+++ b/app/controllers/api/v1/endpoints_controller.rb
@@ -8,9 +8,7 @@ module Api
 
       def create
         endpoint = Endpoint.create!(params_for_create)
-
-        Sources::Api::Events.raise_event("#{model}.create", endpoint.as_json)
-
+        raise_event("#{model}.create", endpoint.as_json)
         render :json => endpoint, :status => :created, :location => instance_link(endpoint)
       end
     end

--- a/app/controllers/api/v1/mixins/destroy_mixin.rb
+++ b/app/controllers/api/v1/mixins/destroy_mixin.rb
@@ -4,7 +4,7 @@ module Api
       module DestroyMixin
         def destroy
           record = model.destroy(params.require(:id))
-          Sources::Api::Events.raise_event("#{model}.destroy", record.as_json)
+          raise_event("#{model}.destroy", record.as_json)
           head :no_content
         end
       end

--- a/app/controllers/api/v1/mixins/update_mixin.rb
+++ b/app/controllers/api/v1/mixins/update_mixin.rb
@@ -4,7 +4,7 @@ module Api
       module UpdateMixin
         def update
           record = model.update(params.require(:id), params_for_update)
-          Sources::Api::Events.raise_event("#{model}.update", record.as_json)
+          raise_event("#{model}.update", record.as_json)
           head :no_content
         end
       end

--- a/app/controllers/api/v1/source_types_controller.rb
+++ b/app/controllers/api/v1/source_types_controller.rb
@@ -6,7 +6,7 @@ module Api
 
       def create
         source_type = model.create!(params_for_create)
-        Sources::Api::Events.raise_event("#{model}.create", source_type.as_json)
+        raise_event("#{model}.create", source_type.as_json)
         render :json => source_type, :status => :created, :location => instance_link(source_type)
       end
     end

--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -11,7 +11,7 @@ module Api
         source_data["uid"] = SecureRandom.uuid if source_data["uid"].nil?
         source = Source.create!(source_data)
 
-        Sources::Api::Events.raise_event("#{model}.create", source.as_json)
+        raise_event("#{model}.create", source.as_json)
 
         render :json => source, :status => :created, :location => instance_link(source)
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,6 +85,11 @@ class ApplicationController < ActionController::API
     send("api_#{version}_#{endpoint}_url", instance.id)
   end
 
+  def raise_event(event, payload)
+    headers = ManageIQ::API::Common::Request.current_forwardable
+    Sources::Api::Events.raise_event(event, payload, headers)
+  end
+
   def params_for_create
     required = api_doc_definition.required_attributes
     body_params.permit(*api_doc_definition.all_attributes).tap { |i| i.require(required) if required }

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -1,13 +1,18 @@
 module Sources
   module Api
     module Events
-      def self.raise_event(event, payload)
+      def self.raise_event(event, payload, headers = nil)
         return if ENV['NO_KAFKA']
-        messaging_client.publish_topic(
+
+        publish_opts = {
           :service => "platform.sources.event-stream",
           :event   => event,
           :payload => payload
-        )
+        }
+
+        publish_opts[:headers] = headers if headers
+
+        messaging_client.publish_topic(publish_opts)
       end
 
       private_class_method def self.messaging_client


### PR DESCRIPTION
When we raise an even on sources crud operations add the
current_forwardable headers to the event headers so that dependent
services know e.g. the tenant/request id that led to the change.

Depends on: ~~https://github.com/ManageIQ/manageiq-messaging/pull/46~~