### PR TITLE
Create Source with given uid

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -7,9 +7,8 @@ module Api
       include Api::V1::Mixins::UpdateMixin
 
       def create
-        binding.pry
         source_data = params_for_create
-        source_data.merge!("uid" => SecureRandom.uuid) if source_data["uid"].nil?
+        source_data["uid"] = SecureRandom.uuid if source_data["uid"].nil?
         source = Source.create!(source_data)
 
         Sources::Api::Events.raise_event("#{model}.create", source.as_json)

--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -7,7 +7,10 @@ module Api
       include Api::V1::Mixins::UpdateMixin
 
       def create
-        source = Source.create!(params_for_create.merge("uid" => SecureRandom.uuid))
+        binding.pry
+        source_data = params_for_create
+        source_data.merge!("uid" => SecureRandom.uuid) if source_data["uid"].nil?
+        source = Source.create!(source_data)
 
         Sources::Api::Events.raise_event("#{model}.create", source.as_json)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,11 @@ class ApplicationController < ActionController::API
     render :json => error_document.to_h, :status => :bad_request
   end
 
+  rescue_from ActiveRecord::RecordNotUnique do |_exception|
+    error_document = ManageIQ::API::Common::ErrorDocument.new.add(400, "Record not unique")
+    render :json => error_document.to_h, :status => :bad_request
+  end
+
   rescue_from ManageIQ::API::Common::Filter::Error do |exception|
     render :json => exception.error_document.to_h, :status => exception.error_document.status
   end

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -84,6 +84,17 @@ RSpec.describe("v1.0 - Sources") do
           :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
         )
       end
+
+      it "failure: with a not unique UID" do
+        post(collection_path, :params => attributes.merge("name" => "aaa", "uid" => "123").to_json, :headers => headers)
+        post(collection_path, :params => attributes.merge("name" => "aaa", "uid" => "123").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "Record not unique").to_h
+        )
+      end
     end
   end
 


### PR DESCRIPTION
For sync between Cloudforms and Sources I need create Source with first payload. 
It means I'll provide UID from CF: `ExtManagementSystem.guid`. 
So I need to create Source with given uid. 