### PR TITLE
Changed openapi ID regexp pattern according to validator

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -401,7 +401,7 @@ class OpenapiGenerator
     }
 
     schemas["ID"] = {
-      "type"=>"string", "description"=>"ID of the resource", "pattern"=>"/^\\d+$/", "readOnly"=>true
+      "type"=>"string", "description"=>"ID of the resource", "pattern"=>"^\\d+$", "readOnly"=>true
     }
 
     schemas["Tenant"] = {

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -908,7 +908,7 @@
         "required": true,
         "schema": {
           "type": "string",
-          "pattern": "/^\\d+$/"
+          "pattern": "^\\d+$"
         }
       },
       "QueryFilter": {
@@ -1197,7 +1197,7 @@
       "ID": {
         "type": "string",
         "description": "ID of the resource",
-        "pattern": "/^\\d+$/",
+        "pattern": "^\\d+$",
         "readOnly": true
       },
       "OrderParameters": {


### PR DESCRIPTION
openapi validator needs ID regexp pattern without "/" at the start and at the end.

* [x] **depends on**: https://github.com/ManageIQ/manageiq-api-common/pull/79

cc @abellotti 