### PR TITLE
POST/PATCH validations against openapi.json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'manageiq-loggers',     '~> 0.1'
 gem 'manageiq-messaging',   '~> 0.1.2', :require => false
 gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"
 gem 'more_core_extensions', '~> 3.5'
-gem 'openapi_parser',       '~> 0.3.0'
 gem 'pg',                   '~> 1.0', :require => false
 gem 'puma',                 '~> 3.0'
 gem 'rack-cors',            '>= 0.4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'manageiq-loggers',     '~> 0.1'
 gem 'manageiq-messaging',   '~> 0.1.2', :require => false
 gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"
 gem 'more_core_extensions', '~> 3.5'
+gem 'openapi_parser',       '~> 0.3.0'
 gem 'pg',                   '~> 1.0', :require => false
 gem 'puma',                 '~> 3.0'
 gem 'rack-cors',            '>= 0.4.1'

--- a/app/controllers/api/graphql_controller.rb
+++ b/app/controllers/api/graphql_controller.rb
@@ -1,5 +1,7 @@
 require "manageiq/api/common/graphql"
 
+skip_before_action :validate_request
+
 module Api
   class GraphqlController < ApplicationController
     def query

--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -401,7 +401,7 @@ class OpenapiGenerator
     }
 
     schemas["ID"] = {
-      "type"=>"string", "description"=>"ID of the resource", "pattern"=>"/^\\d+$/", "readOnly"=>true
+      "type"=>"string", "description"=>"ID of the resource", "pattern"=>"^\\d+$", "readOnly"=>true
     }
 
     schemas["Tenant"] = {

--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -401,7 +401,7 @@ class OpenapiGenerator
     }
 
     schemas["ID"] = {
-      "type"=>"string", "description"=>"ID of the resource", "pattern"=>"^\\d+$", "readOnly"=>true
+      "type" => "string", "description" => "ID of the resource", "pattern" => "^\\d+$", "readOnly" => true
     }
 
     schemas["Tenant"] = {

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -908,7 +908,7 @@
         "required": true,
         "schema": {
           "type": "string",
-          "pattern": "/^\\d+$/"
+          "pattern": "^\\d+$"
         }
       },
       "QueryFilter": {
@@ -1197,7 +1197,7 @@
       "ID": {
         "type": "string",
         "description": "ID of the resource",
-        "pattern": "/^\\d+$/",
+        "pattern": "^\\d+$",
         "readOnly": true
       },
       "OrderParameters": {

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe("v1.0 - Authentications") do
         post(collection_path, :params => payload.merge("password" => 123).to_json, :headers => headers)
 
         expect(response).to have_attributes(
-                              :status => 400,
-                              :location => nil,
-                              :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "123 class is Integer but it's not valid string in #/components/schemas/Authentication/properties/password").to_h
-                            )
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "123 class is Integer but it's not valid string in #/components/schemas/Authentication/properties/password").to_h
+        )
       end
     end
   end

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe("v1.0 - Authentications") do
           :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => payload.merge("password" => 123).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+                              :status => 400,
+                              :location => nil,
+                              :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "123 class is Integer but it's not valid string in #/components/schemas/Authentication/properties/password").to_h
+                            )
+      end
     end
   end
 

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -71,10 +71,10 @@ RSpec.describe("v1.0 - SourceTypes") do
         post(collection_path, :params => attributes.merge("name" => 123).to_json, :headers => headers)
 
         expect(response).to have_attributes(
-                              :status => 400,
-                              :location => nil,
-                              :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "123 class is Integer but it's not valid string in #/components/schemas/SourceType/properties/name").to_h
-                            )
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "123 class is Integer but it's not valid string in #/components/schemas/SourceType/properties/name").to_h
+        )
       end
     end
   end

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe("v1.0 - SourceTypes") do
           :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => attributes.merge("name" => 123).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+                              :status => 400,
+                              :location => nil,
+                              :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "123 class is Integer but it's not valid string in #/components/schemas/SourceType/properties/name").to_h
+                            )
+      end
     end
   end
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe("v1.0 - Sources") do
         )
       end
 
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => attributes.merge("source_type_id" => "xxx").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status => 400,
+          :location => nil,
+          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "xxx isn't match ^\\d+$ in #/components/schemas/ID").to_h
+        )
+      end
+
       it "failure: with a not unique UID" do
         post(collection_path, :params => attributes.merge("name" => "aaa", "uid" => "123").to_json, :headers => headers)
         post(collection_path, :params => attributes.merge("name" => "aaa", "uid" => "123").to_json, :headers => headers)
@@ -176,6 +186,16 @@ RSpec.describe("v1.0 - Sources") do
           :status => 400,
           :parsed_body => {"errors" => [{"detail"=>"found unpermitted parameter: :uid", "status" => 400}]}
         )
+      end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => attributes.merge("source_type_id" => 4).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+                              :status => 400,
+                              :location => nil,
+                              :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "4 class is Integer but it's not valid string in #/components/schemas/ID").to_h
+                            )
       end
     end
   end

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe("v1.0 - Sources") do
         post(collection_path, :params => attributes.merge("source_type_id" => "xxx").to_json, :headers => headers)
 
         expect(response).to have_attributes(
-          :status => 400,
-          :location => nil,
+          :status      => 400,
+          :location    => nil,
           :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "xxx isn't match ^\\d+$ in #/components/schemas/ID").to_h
         )
       end
@@ -192,10 +192,10 @@ RSpec.describe("v1.0 - Sources") do
         post(collection_path, :params => attributes.merge("source_type_id" => 4).to_json, :headers => headers)
 
         expect(response).to have_attributes(
-                              :status => 400,
-                              :location => nil,
-                              :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "4 class is Integer but it's not valid string in #/components/schemas/ID").to_h
-                            )
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "4 class is Integer but it's not valid string in #/components/schemas/ID").to_h
+        )
       end
     end
   end


### PR DESCRIPTION
Create/update requests are validated against openapi.json schema for parameter format. 
It checks only existing properties, unknown properties are checked yet.

---

* [ ] **depends on**: #36 
* [x] **depends on**: https://github.com/ManageIQ/manageiq-api-common/pull/80
* **Issue**: https://github.com/ManageIQ/manageiq-api-common/issues/67