### PR TITLE
[DEPENDS ON https://github.com/ManageIQ/manageiq-api-common/pull/82] Fix constant problems

### DIFF
--- a/app/controllers/api/v1x0.rb
+++ b/app/controllers/api/v1x0.rb
@@ -2,7 +2,7 @@ module Api
   module V1x0
     class RootController < ApplicationController
       def openapi
-        render :json => Api::Docs["1.0"].to_json
+        render :json => ::ManageIQ::API::Common::OpenApi::Docs.instance["1.0"].to_json
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::API
   end
 
   private_class_method def self.api_doc
-    @api_doc ||= Api::Docs[api_version[1..-1].sub(/x/, ".")]
+    @api_doc ||= ::ManageIQ::API::Common::OpenApi::Docs.instance[api_version[1..-1].sub(/x/, ".")]
   end
 
   private_class_method def self.api_doc_definition

--- a/lib/api/docs.rb
+++ b/lib/api/docs.rb
@@ -1,3 +1,0 @@
-module Api
-  Docs = ::ManageIQ::API::Common::OpenApi::Docs.new(Dir.glob(Rails.root.join("public", "doc", "openapi*.json")))
-end

--- a/spec/support/json_schema_matcher.rb
+++ b/spec/support/json_schema_matcher.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :match_json_schema do |version, schema|
   match do |parsed_body|
-    s = Api::Docs[version].definitions[schema]
+    s = ::ManageIQ::API::Common::OpenApi::Docs.instance[version].definitions[schema]
     JSON::Validator.validate!(s, parsed_body)
   end
 end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -9,7 +9,7 @@ describe "Swagger stuff" do
     end
   end
 
-  let(:swagger_routes) { Api::Docs.routes }
+  let(:swagger_routes) { ::ManageIQ::API::Common::OpenApi::Docs.instance.routes }
 
   describe "Routing" do
     include Rails.application.routes.url_helpers
@@ -80,7 +80,7 @@ describe "Swagger stuff" do
   end
 
   describe "Model serialization" do
-    let(:doc) { Api::Docs[version] }
+    let(:doc) { ::ManageIQ::API::Common::OpenApi::Docs.instance[version] }
     let(:authentication) { Authentication.create!(doc.example_attributes("Authentication").symbolize_keys.merge(:tenant => tenant, :resource => endpoint)) }
     let(:endpoint) { Endpoint.create!(doc.example_attributes("Endpoint").symbolize_keys.merge(:tenant => tenant, :source => source)) }
     let(:source) { Source.create!(doc.example_attributes("Source").symbolize_keys.merge(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid)) }
@@ -89,7 +89,7 @@ describe "Swagger stuff" do
 
     context "v1.0" do
       let(:version) { "1.0" }
-      Api::Docs["1.0"].definitions.each do |definition_name, schema|
+      ::ManageIQ::API::Common::OpenApi::Docs.instance["1.0"].definitions.each do |definition_name, schema|
         next if definition_name.in?(["CollectionLinks", "CollectionMetadata", "OrderParameters", "Tagging"])
         definition_name = definition_name.sub(/Collection\z/, "").singularize
 


### PR DESCRIPTION
Occasionally we get an error about missing constant ManageIQ::Api::Docs
which should be actually be finding ::Api::Docs in lib/api/docs.rb in the
apps, but for some reason that isn't loaded yet.  Instead, move all of this
logic to manageiq-api-common and create
::ManageIQ::API::Common::OpenApi::Docs.instance