### PR TITLE
Update README stating dependency on ruby 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This project exposes an API for accessing objects living in the Sources Service database
 
 ## Prerequisites
-You need to install ruby >= 2.2.2 and run:
+You need to install ruby >= 2.4 and run:
 
 ```
 bundle install
@@ -16,6 +16,14 @@ bundle install
 
 ## Getting started
 
+Setup your database configuration
+```
+config/database.dev.yml config/database.yml
+```
+
+Then edit the file to setup your postgres info
+
+Next create the database
 ```
 bin/rake db:create db:migrate
 bin/rails s
@@ -26,6 +34,13 @@ To list all your routes, use:
 ```
 bin/rake routes
 ```
+
+Start your server:
+```
+bin/rails s
+```
+
+This will use kafka by default to send updates for created/updated/deleted actions.  It uses localhost:9092 by default but this can be changed by passing `QUEUE_HOST=` and/or `QUEUE_PORT=`.  To disable kafka updates pass `NO_KAFKA=true`.
 
 ## License
 

--- a/config/database.dev.yml
+++ b/config/database.dev.yml
@@ -1,6 +1,8 @@
 default: &default
   adapter: postgresql
   encoding: utf8
+  host: localhost
+  port: 5432
   username: root
   pool: 5
   wait_timeout: 5


### PR DESCRIPTION
With less than ruby 2.4 you get the following error:

```
NoMethodError (undefined method `named_captures' for #<MatchData:0x00007ff9a3ad4928>):
app/controllers/application_controller.rb:205:in `request_path_parts'
app/controllers/application_controller.rb:209:in `subcollection?'
app/controllers/api/v1/mixins/index_mixin.rb:24:in `raise_unless_primary_instance_exists'
app/controllers/api/v1/mixins/index_mixin.rb:6:in `index'
app/controllers/application_controller.rb:51:in `block (2 levels) in with_current_request'
app/controllers/application_controller.rb:51:in `block in with_current_request'
app/controllers/application_controller.rb:46:in `with_current_request'
```