### PR TITLE
Validate source name is uniqueness within tenant

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -10,7 +10,8 @@ class Source < ApplicationRecord
 
   delegate :scheme, :scheme=, :host, :host=, :port, :port=, :path, :path=,
            :to => :default_endpoint, :allow_nil => true
-  validates :name, :presence => true, :allow_blank => false
+  validates :name, :presence => true, :allow_blank => false,
+            :uniqueness => { :scope => :tenant_id }
 
   def default_endpoint
     default = endpoints.detect(&:default)


### PR DESCRIPTION
Ensure that the name of a source is unique within the tenant while
allowing duplicate names across tenants.

If a duplicate name is provided the error returned will be 400 and the
error doc will say:
Invalid parameter - Validation failed: Name has already been taken

Fixes https://projects.engineering.redhat.com/browse/TPINVTRY-284