### PR TITLE
Add handling of required properties

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -220,10 +220,20 @@ class OpenapiGenerator
       if GENERATOR_READ_ONLY_DEFINITIONS.include?(klass_name) || GENERATOR_READ_ONLY_ATTRIBUTES.include?(key.to_sym)
         # Everything under providers data is read only for now
         properties_value['readOnly'] = true
+      else
+        properties_value['required'] ||= true if required?(klass_name, model, key, value)
       end
 
       properties_value.sort.to_h
     end
+  end
+
+  def required?(_klass_name, model, key, value)
+    nullable = value.null && model.validators_on(key).none? { |v| v.kind == :presence }
+    has_default = value.default.present?
+
+    # If an attribute isn't nullable and has no default then it is required
+    !nullable && !has_default
   end
 
   def openapi_show_description(klass_name)

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -992,6 +992,7 @@
             "$ref": "#/components/schemas/ID"
           },
           "name": {
+            "required": true,
             "type": "string"
           },
           "updated_at": {
@@ -1226,6 +1227,7 @@
           },
           "name": {
             "example": "Sample Provider",
+            "required": true,
             "title": "Name",
             "type": "string"
           },
@@ -1237,6 +1239,7 @@
           },
           "uid": {
             "readOnly": true,
+            "required": true,
             "title": "Unique ID of the inventory source installation",
             "type": "string"
           },
@@ -1266,10 +1269,12 @@
           },
           "name": {
             "example": "openshift",
+            "required": true,
             "type": "string"
           },
           "product_name": {
             "example": "OpenShift",
+            "required": true,
             "type": "string"
           },
           "schema": {
@@ -1282,6 +1287,7 @@
           },
           "vendor": {
             "example": "Red Hat",
+            "required": true,
             "type": "string"
           }
         }


### PR DESCRIPTION
The openapi generator wasn't handling properly if attributes were
required.  This will mark an attribute as required if it isn't in the
set of read-only classes/attributes and if it is not-nullable and
doesn't have a db level default.