### PR TITLE
Required for schemas is a separate section

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -154,11 +154,15 @@ class OpenapiGenerator
   end
 
   def openapi_schema(klass_name)
-    {
+    schema = {
       "type"       => "object",
       "properties" => openapi_schema_properties(klass_name),
-      "required"   => openapi_schema_required(klass_name),
     }
+
+    required = openapi_schema_required(klass_name)
+    schema["required"] = required unless required.empty?
+
+    schema
   end
 
   def openapi_schema_properties(klass_name)

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -975,7 +975,11 @@
             "readOnly": true,
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "source_id",
+          "application_type_id"
+        ]
       },
       "ApplicationType": {
         "type": "object",
@@ -992,7 +996,6 @@
             "$ref": "#/components/schemas/ID"
           },
           "name": {
-            "required": true,
             "type": "string"
           },
           "updated_at": {
@@ -1000,7 +1003,10 @@
             "readOnly": true,
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "name"
+        ]
       },
       "ApplicationTypesCollection": {
         "type": "object",
@@ -1227,7 +1233,6 @@
           },
           "name": {
             "example": "Sample Provider",
-            "required": true,
             "title": "Name",
             "type": "string"
           },
@@ -1239,7 +1244,6 @@
           },
           "uid": {
             "readOnly": true,
-            "required": true,
             "title": "Unique ID of the inventory source installation",
             "type": "string"
           },
@@ -1254,7 +1258,12 @@
             "title": "Version",
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "name",
+          "uid",
+          "source_type_id"
+        ]
       },
       "SourceType": {
         "type": "object",
@@ -1269,12 +1278,10 @@
           },
           "name": {
             "example": "openshift",
-            "required": true,
             "type": "string"
           },
           "product_name": {
             "example": "OpenShift",
-            "required": true,
             "type": "string"
           },
           "schema": {
@@ -1287,10 +1294,14 @@
           },
           "vendor": {
             "example": "Red Hat",
-            "required": true,
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "name",
+          "product_name",
+          "vendor"
+        ]
       },
       "SourceTypesCollection": {
         "type": "object",


### PR DESCRIPTION
For paths, required is just an attribute on the property but for schemas it is its own section at the same level as "properties".  This was causing invalid openapi schemas.