### PR TITLE
Undo required attributes for objects

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -221,20 +221,10 @@ class OpenapiGenerator
       if GENERATOR_READ_ONLY_DEFINITIONS.include?(klass_name) || GENERATOR_READ_ONLY_ATTRIBUTES.include?(key.to_sym)
         # Everything under providers data is read only for now
         properties_value['readOnly'] = true
-      else
-        properties_value['required'] ||= true if required?(klass_name, model, key, value)
       end
 
       properties_value.sort.to_h
     end
-  end
-
-  def required?(_klass_name, model, key, value)
-    nullable = value.null && model.validators_on(key).none? { |v| v.kind == :presence }
-    has_default = value.default.present?
-
-    # If an attribute isn't nullable and has no default then it is required
-    !nullable && !has_default
   end
 
   def openapi_show_description(klass_name)

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -979,7 +979,6 @@
             "$ref": "#/components/schemas/ID"
           },
           "name": {
-            "required": true,
             "type": "string"
           },
           "updated_at": {
@@ -1230,7 +1229,6 @@
           },
           "name": {
             "example": "Sample Provider",
-            "required": true,
             "title": "Name",
             "type": "string"
           },
@@ -1242,7 +1240,6 @@
           },
           "uid": {
             "readOnly": true,
-            "required": true,
             "title": "Unique ID of the inventory source installation",
             "type": "string"
           },
@@ -1272,12 +1269,10 @@
           },
           "name": {
             "example": "openshift",
-            "required": true,
             "type": "string"
           },
           "product_name": {
             "example": "OpenShift",
-            "required": true,
             "type": "string"
           },
           "schema": {
@@ -1290,7 +1285,6 @@
           },
           "vendor": {
             "example": "Red Hat",
-            "required": true,
             "type": "string"
           }
         }


### PR DESCRIPTION
Objects don't have required attribute similar to how endpoints are.
This causes invalid swagger specs.  Introduced by https://github.com/ManageIQ/sources-api/pull/44