### PR TITLE
Reinstating tenant in API responses

### DIFF
--- a/app/models/concerns/tenancy_concern.rb
+++ b/app/models/concerns/tenancy_concern.rb
@@ -5,4 +5,10 @@ module TenancyConcern
     belongs_to :tenant
     acts_as_tenant :tenant
   end
+
+  def as_json(*)
+    super.except("tenant_id").tap do |hash|
+      hash["tenant"] = tenant.external_tenant
+    end
+  end
 end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1053,6 +1053,9 @@
           "status_details": {
             "type": "string"
           },
+          "tenant": {
+            "type": "string"
+          },
           "username": {
             "example": "user@example.com",
             "type": "string"
@@ -1146,6 +1149,9 @@
           "source_id": {
             "$ref": "#/components/schemas/ID"
           },
+          "tenant": {
+            "type": "string"
+          },
           "updated_at": {
             "format": "date-time",
             "readOnly": true,
@@ -1228,6 +1234,9 @@
           },
           "source_type_id": {
             "$ref": "#/components/schemas/ID"
+          },
+          "tenant": {
+            "type": "string"
           },
           "uid": {
             "readOnly": true,

--- a/spec/requests/api/graphql_controller_spec.rb
+++ b/spec/requests/api/graphql_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe("v1.0 - GraphQL") do
       post("/api/v1.0/graphql", :headers => headers, :params => graphql_source_query)
 
       expect(response.status).to eq(200)
+      expect(result_source_tenant(response.body)).to match_array([tenant.external_tenant])
     end
   end
 end

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe("v1.0 - Authentications") do
 
         expect(response).to have_attributes(
           :status => 200,
-          :parsed_body => payload.except("password").merge("id" => instance.id.to_s)
+          :parsed_body => payload.except("password").merge("id" => instance.id.to_s, "tenant" => tenant.external_tenant)
         )
       end
 


### PR DESCRIPTION
Tenant (in this case account number) is necessary in API responses because apps and services subscribing to source
activity messages on kafka need a way to associate them with the specific account making the change.

https://projects.engineering.redhat.com/browse/TPINVTRY-416