### PR TITLE
Fix missing dependent destroy from sources

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -2,7 +2,7 @@ class Endpoint < ApplicationRecord
   include TenancyConcern
   belongs_to :source
 
-  has_many   :authentications, :as => :resource
+  has_many   :authentications, :as => :resource, :dependent => :destroy
 
   validates :role, :uniqueness => { :scope => :source_id }
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -4,7 +4,7 @@ class Source < ApplicationRecord
 
   has_many :applications
   has_many :application_types, :through => :applications
-  has_many :endpoints, :autosave => true
+  has_many :endpoints, :autosave => true, :dependent => :destroy
 
   belongs_to :source_type
 


### PR DESCRIPTION
We were missing the dependent destroy on the sources -> endpoints ->
authentications associations.  This was causing orphaned Authentication
records because the polymorphic authentication relationship couldn't do
a foreign key triggered cascade delete.