### PR TITLE
Fix to the openapi spec to update the CollectionMetadata to include offset and limit

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -370,9 +370,15 @@ class OpenapiGenerator
     }
 
     schemas["CollectionMetadata"] = {
-      "type" => "object",
+      "type"       => "object",
       "properties" => {
-        "count" => {
+        "count"  => {
+          "type" => "integer"
+        },
+        "limit"  => {
+          "type" => "integer"
+        },
+        "offset" => {
           "type" => "integer"
         }
       }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1101,6 +1101,12 @@
         "properties": {
           "count": {
             "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
           }
         }
       },


### PR DESCRIPTION
Fix to the openapi generate rake task and openapi spec so that the collection metadata includes the offset and limit.

Fix for TPINVTRY-569
