### PR TITLE
Add back tenant to openapi schema

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -433,8 +433,10 @@ GENERATOR_BLACKLIST_ATTRIBUTES           = [
   :resource_timestamp, :resource_timestamps, :resource_timestamps_max, :tenant_id
 ].to_set.freeze
 GENERATOR_ALLOW_BLACKLISTED_ATTRIBUTES   = {
+  :tenant_id => ['Source', 'Endpoint', 'Authentication'].to_set.freeze
 }
 GENERATOR_SUBSTITUTE_BLACKLISTED_ATTRIBUTES = {
+  :tenant_id => ["tenant", { "type" => "string" }].freeze
 }
 GENERATOR_READ_ONLY_DEFINITIONS = [
 ].to_set.freeze


### PR DESCRIPTION
Now that we've added tenant back to the API we need to also include the
tenant_id in the generator