### PR TITLE
Add an API to list application_types per source

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
       end
       resources :sources,         :only => [:create, :destroy, :index, :show, :update] do
         resources :applications, :only => [:index]
+        resources :application_types, :only => [:index]
         resources :endpoints, :only => [:index]
       end
     end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -829,6 +829,39 @@
         }
       }
     },
+    "/sources/{id}/application_types": {
+      "get": {
+        "summary": "List ApplicationTypes for Source",
+        "operationId": "listSourceApplicationTypes",
+        "description": "Returns an array of ApplicationType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationTypesCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sources/{id}/applications": {
       "get": {
         "summary": "List Applications for Source",


### PR DESCRIPTION
Simplify the work of getting the list of application_types that a source
is enabled for by allowing a caller to go directly to the
application_types through applications.

```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1In19" http://localhost:3000/api/v1.0/sources/1/application_types 2>/dev/null | python -m json.tool
{
    "data": [
        {
            "created_at": "2019-08-21T12:42:18Z",
            "display_name": "Catalog",
            "id": "1",
            "name": "/insights/platform/catalog",
            "updated_at": "2019-08-21T12:42:18Z"
        }
    ],
    "links": {
        "first": "/api/v1.0/sources/1/application_types?offset=0",
        "last": "/api/v1.0/sources/1/application_types?offset=0"
    },
    "meta": {
        "count": 1,
        "limit": 100,
        "offset": 0
    }
}
```

Fixes https://projects.engineering.redhat.com/browse/TPINVTRY-218