### PR TITLE
Add a dependent_applications to application_types

### DIFF
--- a/db/migrate/20190823150955_add_dependent_applications_to_application_types.rb
+++ b/db/migrate/20190823150955_add_dependent_applications_to_application_types.rb
@@ -1,0 +1,5 @@
+class AddDependentApplicationsToApplicationTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :application_types, :dependent_applications, :jsonb
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,6 +61,6 @@ update_or_create(SourceType, :name => "ovirt", :product_name => "Red Hat Virtual
 update_or_create(SourceType, :name => "openstack", :product_name => "Red Hat OpenStack", :vendor => "Red Hat")
 update_or_create(SourceType, :name => "cloudforms", :product_name => "Red Hat CloudForms", :vendor => "Red Hat")
 
-update_or_create(ApplicationType, :name => "/insights/platform/catalog",               :display_name => "Catalog")
-update_or_create(ApplicationType, :name => "/insights/platform/cost-management",       :display_name => "Cost Management")
-update_or_create(ApplicationType, :name => "/insights/platform/topological-inventory", :display_name => "Topological Inventory")
+update_or_create(ApplicationType, :name => "/insights/platform/catalog",               :display_name => "Catalog",               :dependent_applications => ["/insights/platform/topological-inventory"])
+update_or_create(ApplicationType, :name => "/insights/platform/cost-management",       :display_name => "Cost Management",       :dependent_applications => [])
+update_or_create(ApplicationType, :name => "/insights/platform/topological-inventory", :display_name => "Topological Inventory", :dependent_applications => [])


### PR DESCRIPTION
Add a list of dependent application type names to an application_type, and mark that catalog depends on topological-inventory.

This can be used by the orchestrator to generically determine which sources to spin collectors up for by dynamically checking the authentication_types as opposed to the hard-coded list that we currently have.