### PR TITLE
Add supported_source_types and _authentication_types to application_type

### DIFF
--- a/db/migrate/20190823151426_add_supported_source_types_to_application_types.rb
+++ b/db/migrate/20190823151426_add_supported_source_types_to_application_types.rb
@@ -1,0 +1,5 @@
+class AddSupportedSourceTypesToApplicationTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :application_types, :supported_source_types, :jsonb
+  end
+end

--- a/db/migrate/20190823201412_add_supported_authentication_types.rb
+++ b/db/migrate/20190823201412_add_supported_authentication_types.rb
@@ -1,0 +1,5 @@
+class AddSupportedAuthenticationTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :application_types, :supported_authentication_types, :jsonb
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,17 +62,27 @@ update_or_create(SourceType, :name => "openstack", :product_name => "Red Hat Ope
 update_or_create(SourceType, :name => "cloudforms", :product_name => "Red Hat CloudForms", :vendor => "Red Hat")
 
 update_or_create(ApplicationType,
-                 :name                   => "/insights/platform/catalog",
-                 :display_name           => "Catalog",
-                 :dependent_applications => ["/insights/platform/topological-inventory"],
-                 :supported_source_types => ["ansible_tower", "amazon"])
+                 :name                           => "/insights/platform/catalog",
+                 :display_name                   => "Catalog",
+                 :dependent_applications         => ["/insights/platform/topological-inventory"],
+                 :supported_source_types         => ["ansible_tower"],
+                 :supported_authentication_types => {"ansible_tower" => ["username_password"]})
+
 update_or_create(ApplicationType,
-                 :name                   => "/insights/platform/cost-management",
-                 :display_name           => "Cost Management",
-                 :dependent_applications => [],
-                 :supported_source_types => ["amazon"])
+                 :name                           => "/insights/platform/cost-management",
+                 :display_name                   => "Cost Management",
+                 :dependent_applications         => [],
+                 :supported_source_types         => ["amazon"],
+                 :supported_authentication_types => {"amazon" => ["arn"]})
+
 update_or_create(ApplicationType,
-                 :name                   => "/insights/platform/topological-inventory",
-                 :display_name           => "Topological Inventory",
-                 :dependent_applications => [],
-                 :supported_source_types => ["amazon", "ansible_tower", "azure", "openshift"])
+                 :name                           => "/insights/platform/topological-inventory",
+                 :display_name                   => "Topological Inventory",
+                 :dependent_applications         => [],
+                 :supported_source_types         => ["amazon", "ansible_tower", "azure", "openshift"],
+                 :supported_authentication_types => {
+                   "amazon"        => ["access_key_secret_key"],
+                   "ansible_tower" => ["username_password"],
+                   "azure"         => ["username_password"],
+                   "openshift"     => ["token"]
+                 })

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,6 +61,18 @@ update_or_create(SourceType, :name => "ovirt", :product_name => "Red Hat Virtual
 update_or_create(SourceType, :name => "openstack", :product_name => "Red Hat OpenStack", :vendor => "Red Hat")
 update_or_create(SourceType, :name => "cloudforms", :product_name => "Red Hat CloudForms", :vendor => "Red Hat")
 
-update_or_create(ApplicationType, :name => "/insights/platform/catalog",               :display_name => "Catalog",               :dependent_applications => ["/insights/platform/topological-inventory"])
-update_or_create(ApplicationType, :name => "/insights/platform/cost-management",       :display_name => "Cost Management",       :dependent_applications => [])
-update_or_create(ApplicationType, :name => "/insights/platform/topological-inventory", :display_name => "Topological Inventory", :dependent_applications => [])
+update_or_create(ApplicationType,
+                 :name                   => "/insights/platform/catalog",
+                 :display_name           => "Catalog",
+                 :dependent_applications => ["/insights/platform/topological-inventory"],
+                 :supported_source_types => ["ansible_tower", "amazon"])
+update_or_create(ApplicationType,
+                 :name                   => "/insights/platform/cost-management",
+                 :display_name           => "Cost Management",
+                 :dependent_applications => [],
+                 :supported_source_types => ["amazon"])
+update_or_create(ApplicationType,
+                 :name                   => "/insights/platform/topological-inventory",
+                 :display_name           => "Topological Inventory",
+                 :dependent_applications => [],
+                 :supported_source_types => ["amazon", "ansible_tower", "azure", "openshift"])

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1039,6 +1039,9 @@
             "readOnly": true,
             "type": "string"
           },
+          "dependent_applications": {
+            "type": "object"
+          },
           "display_name": {
             "type": "string"
           },
@@ -1047,6 +1050,12 @@
           },
           "name": {
             "type": "string"
+          },
+          "supported_authentication_types": {
+            "type": "object"
+          },
+          "supported_source_types": {
+            "type": "object"
           },
           "updated_at": {
             "format": "date-time",


### PR DESCRIPTION
Adds a list of supported source_types and for those source_types what authentication_type is supported for the different application_types
This can be used by the UI to dynamically determine what apps can be enabled for the different sources.