### PR TITLE
Remove unnecessary call to :as_json

### DIFF
--- a/app/controllers/internal/v1/tenants_controller.rb
+++ b/app/controllers/internal/v1/tenants_controller.rb
@@ -6,7 +6,7 @@ module Internal
       end
 
       def show
-        render json: model.find(params.require(:id)).as_json(:prefixes => [request.path])
+        render json: model.find(params.require(:id))
       end
     end
   end


### PR DESCRIPTION
The `as_json` method in ManageIQ::Api::Common will be called with the correct prefixes from `render :json => ...`