### PR TITLE
Rename fields in DDF form schemas

### DIFF
--- a/db/seeds/source_types.rb
+++ b/db/seeds/source_types.rb
@@ -10,12 +10,12 @@ end
 openshift_json_schema = {
   :title  => "Configure OpenShift",
   :fields => [
-    {:component => "text-field", :name => "role", :type => "hidden", :initialValue => "kubernetes"},
-    {:component => "text-field", :name => "authtype", :type => "hidden", :initialValue => "token"},
+    {:component => "text-field", :name => "endpoint.role", :type => "hidden", :initialValue => "kubernetes"},
+    {:component => "text-field", :name => "authentication.authtype", :type => "hidden", :initialValue => "token"},
     {:component => "text-field", :name => "url", :label => "URL"},
-    {:component => "checkbox", :name => "verify_ssl", :label => "Verify SSL"},
-    {:component => "text-field", :name => "certificate_authority", :label => "Certificate Authority", :condition => {:when => "verify_ssl", :is => true}},
-    {:component => "text-field", :name => "token", :label => "Token", :type => "password"}
+    {:component => "checkbox", :name => "endpoint.verify_ssl", :label => "Verify SSL"},
+    {:component => "text-field", :name => "endpoint.certificate_authority", :label => "Certificate Authority", :condition => {:when => "endpoint.verify_ssl", :is => true}},
+    {:component => "text-field", :name => "authentication.password", :label => "Token", :type => "password"}
   ]
 }
 
@@ -30,10 +30,10 @@ update_or_create(
 amazon_json_schema = {
   :title  => "Configure AWS",
   :fields => [
-    {:component => "text-field", :name => "role", :type => "hidden", :initialValue => "aws"},
-    {:component => "text-field", :name => "authtype", :type => "hidden", :initialValue => "access_key_secret_key"},
-    {:component => "text-field", :name => "username", :label => "Access Key"},
-    {:component => "text-field", :name => "password", :label => "Secret Key", :type => "password"}
+    {:component => "text-field", :name => "endpoint.role", :type => "hidden", :initialValue => "aws"},
+    {:component => "text-field", :name => "authentication.authtype", :type => "hidden", :initialValue => "access_key_secret_key"},
+    {:component => "text-field", :name => "authentication.username", :label => "Access Key"},
+    {:component => "text-field", :name => "authentication.password", :label => "Secret Key", :type => "password"}
   ]
 }
 update_or_create(
@@ -47,11 +47,11 @@ update_or_create(
 azure_json_schema = {
   :title  => "Configure Azure",
   :fields => [
-    {:component => "text-field", :name => "role", :type => "hidden", :initialValue => "azure"},
-    {:component => "text-field", :name => "authtype", :type => "hidden", :initialValue => "access_key_secret_key"},
-    {:component => "text-field", :name => "extra.azure.tenant_id", :label => "Tenant ID"},
-    {:component => "text-field", :name => "username", :label => "Client ID"},
-    {:component => "text-field", :name => "password", :label => "Client Secret", :type => "password"}
+    {:component => "text-field", :name => "endpoint.role", :type => "hidden", :initialValue => "azure"},
+    {:component => "text-field", :name => "authentication.authtype", :type => "hidden", :initialValue => "access_key_secret_key"},
+    {:component => "text-field", :name => "authentication.extra.azure.tenant_id", :label => "Tenant ID"},
+    {:component => "text-field", :name => "authentication.username", :label => "Client ID"},
+    {:component => "text-field", :name => "authentication.password", :label => "Client Secret", :type => "password"}
   ]
 }
 
@@ -60,13 +60,13 @@ update_or_create(:name => "azure", :product_name => "Microsoft Azure", :vendor =
 ansible_tower_json_schema = {
   :title  => "Configure AnsibleTower",
   :fields => [
-    {:component => "text-field", :name => "role", :type => "hidden", :initialValue => "ansible"}, # FIXME: Find the correct value.
-    {:component => "text-field", :name => "authtype", :type => "hidden", :initialValue => "username_password"},
+    {:component => "text-field", :name => "endpoint.role", :type => "hidden", :initialValue => "ansible"}, # FIXME: Find the correct value.
+    {:component => "text-field", :name => "authentication.authtype", :type => "hidden", :initialValue => "username_password"},
     {:component => "text-field", :name => "url", :label => "URL"},
-    {:component => "checkbox", :name => "verify_ssl", :label => "Verify SSL"},
-    {:component => "text-field", :name => "certificate_authority", :label => "Certificate Authority", :condition => {:when => "verify_ssl", :is => true}},
-    {:component => "text-field", :name => "username", :label => "User name"},
-    {:component => "text-field", :name => "password", :label => "Secret Key", :type => "password"}
+    {:component => "checkbox", :name => "endpoint.verify_ssl", :label => "Verify SSL"},
+    {:component => "text-field", :name => "endpoint.certificate_authority", :label => "Certificate Authority", :condition => {:when => "endpoint.verify_ssl", :is => true}},
+    {:component => "text-field", :name => "authentication.username", :label => "User name"},
+    {:component => "text-field", :name => "authentication.password", :label => "Secret Key", :type => "password"}
   ]
 }
 


### PR DESCRIPTION
**Description**

Renames form fields in DDF to allow better handling in UI.

@Ladas Is the  `authentication.extra.azure.tenant_id` the right endpoint (authentication) ?

Merge together with Sources-UI (https://github.com/ManageIQ/sources-ui/pull/94), and after frontend-components-sources (https://github.com/RedHatInsights/frontend-components/pull/132)
