### PR TITLE
Don't run db:migrate and db:seed together

### DIFF
--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -28,5 +28,6 @@ write_encryption_key
 # Wait for postgres to be ready
 check_svc_status $DATABASE_HOST $DATABASE_PORT
 
-bundle exec rake db:migrate db:seed
+bundle exec rake db:migrate
+bundle exec rake db:seed
 bundle exec rails server


### PR DESCRIPTION
Fix a caching issue when running db:migrate and db:seed from the same
rake invocation

This was leading to:

```
rake db:migrate db:seed
...
ActiveModel::UnknownAttributeError: unknown attribute 'icon_url' for SourceType.
/opt/sources-api/db/seeds/source_types.rb:6:in `update_or_create'
/opt/sources-api/db/seeds/source_types.rb:22:in `<top (required)>'
/opt/sources-api/db/seeds.rb:2:in `block in <top (required)>'
/opt/sources-api/db/seeds.rb:2:in `each'
/opt/sources-api/db/seeds.rb:2:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => db:seed
```