### PR TITLE
Add a endpoints.receptor_node attribute

### DIFF
--- a/db/migrate/20190919143736_add_receptor_node_id_to_endpoints.rb
+++ b/db/migrate/20190919143736_add_receptor_node_id_to_endpoints.rb
@@ -1,0 +1,5 @@
+class AddReceptorNodeIdToEndpoints < ActiveRecord::Migration[5.2]
+  def change
+    add_column :endpoints, :receptor_node, :string
+  end
+end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1236,6 +1236,10 @@
             "example": 80,
             "type": "integer"
           },
+          "receptor_node": {
+            "description": "Identifier of a receptor node",
+            "type": "string"
+          },
           "role": {
             "example": "default",
             "type": "string"


### PR DESCRIPTION
Add a receptor_node attribute for an endpoint to allow for tracking of
customer receptor nodes.  This will facilitate communication from
cloud.redhat.com through a c.r.c. controller to a customer's
environment.