### PR TITLE
Fix typo in application_types.db

### DIFF
--- a/db/seeds/application_types.rb
+++ b/db/seeds/application_types.rb
@@ -11,8 +11,8 @@ update_or_create(
   :name                           => "/insights/platform/catalog",
   :display_name                   => "Catalog",
   :dependent_applications         => ["/insights/platform/topological-inventory"],
-  :supported_source_types         => ["ansible_tower"],
-  :supported_authentication_types => {"ansible_tower" => ["username_password"]}
+  :supported_source_types         => ["ansible-tower"],
+  :supported_authentication_types => {"ansible-tower" => ["username_password"]}
 )
 
 update_or_create(
@@ -31,10 +31,10 @@ update_or_create(
   :name                           => "/insights/platform/topological-inventory",
   :display_name                   => "Topological Inventory",
   :dependent_applications         => [],
-  :supported_source_types         => ["amazon", "ansible_tower", "azure", "openshift"],
+  :supported_source_types         => ["amazon", "ansible-tower", "azure", "openshift"],
   :supported_authentication_types => {
     "amazon"        => ["access_key_secret_key"],
-    "ansible_tower" => ["username_password"],
+    "ansible-tower" => ["username_password"],
     "azure"         => ["username_password"],
     "openshift"     => ["token"]
   }


### PR DESCRIPTION
In application_types it is `ansible_tower`, in source types it is `ansible-tower`.

I changed it to `ansible_tower` in source-types. I am not sure what naming system are we going to use, but it makes sense to use the name with `_` as it is a standard Ruby syntax.

Do I need to write any migration? 

@gtanzillo @agrare 