### PR TITLE
Now empty bodies are allowed by the API

### DIFF
--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -77,16 +77,6 @@ RSpec.describe("v1.0 - Authentications") do
                             )
       end
 
-      it "failure: with no body" do
-        post(collection_path, :headers => headers)
-
-        expect(response).to have_attributes(
-          :status => 400,
-          :location => nil,
-          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "Failed to parse request body, expected JSON").to_h
-        )
-      end
-
       it "failure: with extra attributes" do
         post(collection_path, :params => payload.merge("aaa" => "bbb").to_json, :headers => headers)
 

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -47,16 +47,6 @@ RSpec.describe("v1.0 - SourceTypes") do
         )
       end
 
-      it "failure: with no body" do
-        post(collection_path, :headers => headers)
-
-        expect(response).to have_attributes(
-          :status => 400,
-          :location => nil,
-          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "Failed to parse request body, expected JSON").to_h
-        )
-      end
-
       it "failure: with extra attributes" do
         post(collection_path, :params => attributes.merge("aaa" => "bbb").to_json, :headers => headers)
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -45,16 +45,6 @@ RSpec.describe("v1.0 - Sources") do
         )
       end
 
-      it "failure: with no body" do
-        post(collection_path, :headers => headers)
-
-        expect(response).to have_attributes(
-          :status => 400,
-          :location => nil,
-          :parsed_body => ManageIQ::API::Common::ErrorDocument.new.add(400, "Failed to parse request body, expected JSON").to_h
-        )
-      end
-
       it "failure: with a missing name attribute" do
         post(collection_path, :params => attributes.except("name").to_json, :headers => headers)
 


### PR DESCRIPTION
ManageIQ/manageiq-api-common#93 allows empty bodies so these tests no
longer match the api-common expectations.