### PR TITLE
Add return type to getDocumentation /openapi.json

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -571,7 +571,14 @@
         "operationId": "getDocumentation",
         "responses": {
           "200": {
-            "description": "The API document for this version of the API"
+            "description": "The API document for this version of the API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
There was no return type defined for getDocumentation so generated
clients were not picking this endpoint up.

TPINVTRY-515