### PR TITLE
Fix Azure authentication_type

### DIFF
--- a/db/seeds/application_types.rb
+++ b/db/seeds/application_types.rb
@@ -22,7 +22,7 @@ update_or_create(
   :supported_source_types         => ["amazon", "azure", "openshift"],
   :supported_authentication_types => {
     "amazon"    => ["arn"],
-    "azure"     => ["username_password"],
+    "azure"     => ["tenant_id_client_id_client_secret"],
     "openshift" => ["token"]
   }
 )
@@ -35,7 +35,7 @@ update_or_create(
   :supported_authentication_types => {
     "amazon"        => ["access_key_secret_key"],
     "ansible-tower" => ["username_password"],
-    "azure"         => ["username_password"],
+    "azure"         => ["tenant_id_client_id_client_secret"],
     "openshift"     => ["token"]
   }
 )

--- a/db/seeds/source_types.rb
+++ b/db/seeds/source_types.rb
@@ -63,10 +63,10 @@ update_or_create(
 
 azure_json_schema = {
   :authentication => [{
-    :type   => 'access_key_secret_key',
-    :name   => "Username and password",
+    :type   => 'tenant_id_client_id_client_secret',
+    :name   => "Tenant ID, Client ID, Client Secret",
     :fields => [
-      {:component => "text-field", :name => "authentication.authtype", :hideField => true, :initialValue => "access_key_secret_key"},
+      {:component => "text-field", :name => "authentication.authtype", :hideField => true, :initialValue => "tenant_id_client_id_client_secret"},
       {:component => "text-field", :name => "authentication.extra.azure.tenant_id", :label => "Tenant ID"},
       {:component => "text-field", :name => "authentication.username", :label => "Client ID"},
       {:component => "text-field", :name => "authentication.password", :label => "Client Secret", :type => "password"}


### PR DESCRIPTION
The Azure authentication_type was an access_key_secret_key type even
though the application_type specified username_password and azure also
includes a tenant_id field.

Introduce a new authentication_type to track the azure credential type.

Fixes https://github.com/ManageIQ/sources-api/issues/101