### PR TITLE
Lockdown sprockets to ~>3.0 to fix failure on 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'pg',                   '~> 1.0', :require => false
 gem 'puma',                 '~> 3.0'
 gem 'rack-cors',            '>= 0.4.1'
 gem 'rails',                '~> 5.2.2'
+gem 'sprockets',            '~> 3.0', :require => false
 
 group :development, :test do
   gem 'rubocop',             '~>0.69.0', :require => false


### PR DESCRIPTION
Sprockets 4.0 requires ruby 2.5 or higher:

https://travis-ci.org/ManageIQ/sources-api/jobs/596214534#L326
```
Installing sprockets 4.0.0
Gem::RuntimeRequirementNotMetError: sprockets requires Ruby version >= 2.5.0.
The current ruby version is 2.4.0.
An error occurred while installing sprockets (4.0.0), and Bundler
cannot continue.
```