### PR TITLE
Fix hakiri warning about sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'pg',                   '~> 1.0', :require => false
 gem 'puma',                 '~> 3.0'
 gem 'rack-cors',            '>= 0.4.1'
 gem 'rails',                '~> 5.2.2'
-gem 'sprockets',            '~> 3.0', :require => false
+gem 'sprockets',            '>= 3.7.2', '< 4.0', :require => false
 
 group :development, :test do
   gem 'rubocop',             '~>0.69.0', :require => false


### PR DESCRIPTION
We need < 4.0 to pass on ruby 2.4 and we need >= 3.7.2 for an information disclosure issue