### PR TITLE
Add arn auth_type for aws+cm

### DIFF
--- a/db/seeds/source_types.rb
+++ b/db/seeds/source_types.rb
@@ -44,6 +44,36 @@ amazon_json_schema = {
       {:component => "text-field", :name => "authentication.username", :label => "Access Key"},
       {:component => "text-field", :name => "authentication.password", :label => "Secret Key", :type => "password"}
     ]
+  }, {
+    :type   => 'arn',
+    :name   => 'ARN',
+    :fields => [{
+      :component    => 'text-field',
+      :name         => 'authentication.authtype',
+      :hideField    => true,
+      :initialValue => 'arn'
+    }, {
+      :name       => 'billing_source.bucket',
+      :stepKey    => 'amazon-arn-additional-step',
+      :component  => 'text-field',
+      :label      => 'S3 bucket name',
+      :isRequired => true,
+      :validate   => [
+        { :type=>  'required-validator' },
+        { :type => 'pattern-validator', :pattern => '^[A-Za-z0-9]+[A-Za-z0-9_-]*$' }
+      ]
+    }, {
+      :name       => 'authentication.password',
+      :stepKey    => 'arn',
+      :component  => 'text-field',
+      :label      => 'ARN',
+      :isRequired => true,
+      :validate   => [
+        { :type => 'required-validator' },
+        { :type => 'pattern-validator', :pattern => '^arn:aws:.*' },
+        { :type => 'min-length-validator', :threshold => 10 }
+      ]
+    }],
   }],
   :endpoint       => {
     :hidden => true,


### PR DESCRIPTION
**Description**

- Adds ARN DDF schema for ARN for AWS/CM.
    - basic structure and input fields
    - Tags step is skipped until we get exact steps

`description` component is a component, where the content is added on the UI side, because it's a complex task to write these components into the schema without using Javascript syntax. (It uses bullet lists, copy clipboard components, etc.) However, if we decide that we want to store everything in the DB, it can be done, but it will take some time to come up with a good solution. (We could probably used some `md` parser... Client Side has advantages: it's simple and it can be easily localized.) 

~~_Waiting for completion of the UI implementation._~~

Work-in-progress: https://github.com/RedHatInsights/frontend-components/pull/212

