### PR TITLE
Switch to sprockets 4.0 and drop ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 language: ruby
 cache: bundler
 rvm:
-- 2.4.5
 - 2.5.3
 addons:
   postgresql: '10'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'pg',                   '~> 1.0', :require => false
 gem 'puma',                 '~> 3.0'
 gem 'rack-cors',            '>= 0.4.1'
 gem 'rails',                '~> 5.2.2'
-gem 'sprockets',            '>= 3.7.2', '< 4.0', :require => false
+gem 'sprockets',            '~> 4.0'
 
 group :development, :test do
   gem 'rubocop',             '~>0.69.0', :require => false


### PR DESCRIPTION
Even limiting sprockets to what hakiri says are the patched versions didn't clear the security error, only bumping to sprockets 4.0 works.  To do this had to drop ruby 2.4 which sprockets 4.0 doesn't support and we don't use on our images anyway.