### PR TITLE
Update to manageiq-api-common 2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
-gem 'manageiq-api-common',  '~> 2.0'
+gem 'manageiq-api-common',  '~> 2.0', '>= 2.0.1'
 gem 'manageiq-loggers',     '~> 0.1'
 gem 'manageiq-messaging',   '~> 0.1.5', :require => false
 gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,8 @@ class ApplicationController < ActionController::API
   end
 
   rescue_from ManageIQ::API::Common::Filter::Error do |exception|
-    render :json => exception.error_document.to_h, :status => exception.error_document.status
+    error_document = ManageIQ::API::Common::ErrorDocument.new.add(400, exception)
+    render :json => error_document.to_h, :status => error_document.status
   end
 
   rescue_from ActiveRecord::NotNullViolation do |exception|


### PR DESCRIPTION
Update to v2.0.1 of manageiq-api-common and fix the filter error
exception handling changed in https://github.com/ManageIQ/manageiq-api-common/pull/125