### PR TITLE
Add AvailabilityStatus to Applications, Authentications, and Endpoints

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -2,4 +2,7 @@ class Application < ApplicationRecord
   include TenancyConcern
   belongs_to :source
   belongs_to :application_type
+
+  attribute :availability_status, :string
+  validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
 end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -4,4 +4,7 @@ class Authentication < ApplicationRecord
   encrypt_column :password
 
   belongs_to :resource, :polymorphic => true
+
+  attribute :availability_status, :string
+  validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
 end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -6,6 +6,9 @@ class Endpoint < ApplicationRecord
 
   validates :role, :uniqueness => { :scope => :source_id }
 
+  attribute :availability_status, :string
+  validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
+
   def base_url_path
     URI::Generic.build(:scheme => scheme, :host => host, :port => port, :path => path).to_s
   end

--- a/db/migrate/20191028194041_add_availablility_status.rb
+++ b/db/migrate/20191028194041_add_availablility_status.rb
@@ -1,0 +1,10 @@
+class AddAvailablilityStatus < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applications,    :availability_status,       :string
+    add_column :applications,    :availability_status_error, :string
+    add_column :authentications, :availability_status,       :string
+    add_column :authentications, :availability_status_error, :string
+    add_column :endpoints,       :availability_status,       :string
+    add_column :endpoints,       :availability_status_error, :string
+  end
+end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1151,6 +1151,12 @@
           "application_type_id": {
             "$ref": "#/components/schemas/ID"
           },
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
+            "type": "string"
+          },
           "created_at": {
             "format": "date-time",
             "readOnly": true,
@@ -1247,6 +1253,12 @@
         "properties": {
           "authtype": {
             "example": "openshift_default",
+            "type": "string"
+          },
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
             "type": "string"
           },
           "extra": {
@@ -1350,6 +1362,12 @@
       "Endpoint": {
         "type": "object",
         "properties": {
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
+            "type": "string"
+          },
           "certificate_authority": {
             "description": "Optional X.509 Certificate Authority",
             "type": "string"


### PR DESCRIPTION
Add AvailabilityStatus to Applications, Authentications, and Endpoints.

Extend the granularity of availability_status by allowing more resources
to contain availability status and an error message.