### PR TITLE
Add a Red Hat Satellite source-type

### DIFF
--- a/db/seeds/source_types.rb
+++ b/db/seeds/source_types.rb
@@ -138,3 +138,4 @@ update_or_create(:name => "vsphere", :product_name => "VMware vSphere", :vendor 
 update_or_create(:name => "ovirt", :product_name => "Red Hat Virtualization", :vendor => "Red Hat")
 update_or_create(:name => "openstack", :product_name => "Red Hat OpenStack", :vendor => "Red Hat")
 update_or_create(:name => "cloudforms", :product_name => "Red Hat CloudForms", :vendor => "Red Hat")
+update_or_create(:name => "satellite", :product_name => "Red Hat Satellite", :vendor => "Red Hat")


### PR DESCRIPTION
Add a satellite source type for tracking on premise satellite
installations to track receptor endpoints.